### PR TITLE
Added "grunt-cli" to devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: node_js
 node_js:
   - "0.10"
-before_script:
-  - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "grunt-contrib-nodeunit": "0.2.0",
     "grunt-contrib-uglify": "0.2.2",
     "grunt-contrib-watch": "0.4.4",
+    "grunt-cli": "0.1.9",
     "emu": "0.0.2"
   },
   "main": "bilby.js",


### PR DESCRIPTION
After cloning bilby and installing nodejs, I ran into this error:

```
$ npm test

> bilby@0.1.0 test /vagrant/Developer/bilby.js
> grunt rig jshint nodeunit uglify emu

sh: grunt: not found
```

I think the reason is this: "Grunt no longer ships with a binary. In order to get the grunt command, install grunt-cli."

http://gruntjs.com/blog/2013-02-18-grunt-0.4.0-released

So in this pull request, I propose to add grunt-cli to the devDependencies.

Cheers!
Sébastien.
